### PR TITLE
Forward all messages from CEGA to local 'files' queue

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,10 @@ func forwardDeliveryTo(fromCEGAToLEGA bool, channelFrom *amqp.Channel, channelTo
 		err = publishError(delivery, err)
 		failOnError(err, "Failed to publish error message")
 	}
-	if messageType != nil {
+	// Forward all messages from CEGA to a local queue handled by the SDA intercept service
+	if fromCEGAToLEGA {
+		routingKey = os.Getenv("LEGA_MQ_QUEUE")
+	} else if messageType != nil {
 		routingKey = messageType.(string)
 	}
 	err = channelTo.Publish(exchange, routingKey, false, false, *publishing)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read TrackFind's "Contributing Guideline". -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Unit/integration tests
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
All messages from CEGA to LEGA will be forwarded to a single local queue where they can later be handled by the SDA intercept service. The name of the queue is configured with the `LEGA_MQ_QUEUE` environment variable.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
This commit is related to the "cancel messages" functionality implemented by [PR#498](https://github.com/neicnordic/sda-pipeline/pull/498) in the SDA-pipeline repository.

